### PR TITLE
Add all database objects to the repository

### DIFF
--- a/database_objects/BookKeeping_devel_functions/BookKeeping_devel_functions.ssmssqlproj
+++ b/database_objects/BookKeeping_devel_functions/BookKeeping_devel_functions.ssmssqlproj
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<SqlWorkbenchSqlProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BookKeeping_devel_functions">
+  <Items>
+    <LogicalFolder Name="Connections" Type="2" Sorted="true">
+      <Items>
+        <ConnectionNode Name="MM-WCHS001:devel_edvard">
+          <Created>2017-07-27T14:23:37.3979947+02:00</Created>
+          <Type>SQL</Type>
+          <Server>MM-WCHS001</Server>
+          <UserName>devel_edvard</UserName>
+          <Authentication>SQL</Authentication>
+          <InitialDB>BookKeeping</InitialDB>
+          <LoginTimeout>15</LoginTimeout>
+          <ExecutionTimeout>0</ExecutionTimeout>
+          <ConnectionProtocol>NotSpecified</ConnectionProtocol>
+          <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
+        </ConnectionNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Queries" Type="0" Sorted="true">
+      <Items>
+        <FileNode Name="dbo.fGetAuthorityId.UserDefinedFunction.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
+          <FullPath>dbo.fGetAuthorityId.UserDefinedFunction.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.fGetAuthorityIdFromSysUser.UserDefinedFunction.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.fGetAuthorityIdFromSysUser.UserDefinedFunction.sql</FullPath>
+        </FileNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Miscellaneous" Type="3" Sorted="true">
+      <Items />
+    </LogicalFolder>
+  </Items>
+</SqlWorkbenchSqlProject>

--- a/database_objects/BookKeeping_devel_functions/dbo.fGetAuthorityId.sql
+++ b/database_objects/BookKeeping_devel_functions/dbo.fGetAuthorityId.sql
@@ -1,0 +1,61 @@
+USE [BookKeeping]
+GO
+/****** Object:  UserDefinedFunction [dbo].[fGetAuthorityId]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE FUNCTION [dbo].[fGetAuthorityId]() RETURNS INTEGER
+AS
+BEGIN
+
+	DECLARE @authority_id INTEGER 
+	DECLARE @sys_user VARCHAR(255)
+	DECLARE @spid INT
+
+	SET @authority_id = -1
+	SET @spid = @@spid
+
+	-- User logged in i lab-mode (Chiasma and Order) cannot be identified by 
+	-- SYSTEM_USER, so the table authority_session_mapping must be used.
+	-- A system admin working from SQL Server Management Studio is not listed in the
+	-- table authority_session_mapping, and is therefore identified through SYSTEM_USER
+
+	-- In rare occurances, the table authority_session_mapping (a.s.m.) may not be updated when a 
+	-- user logg off (not normal logouts), and the session-id for the 
+	-- MSS Management Studio may then be the same as the inactive session_id 
+	-- in the a.s.m. table. 
+	-- 
+
+	-- Check if authority is found in the authority_session_mapping table
+	select	@authority_id = authority_id 
+	from	authority_session_mapping 
+	where	session_id = @spid
+
+	IF @authority_id = -1
+	BEGIN
+		-- Authority not found in the authority_session_mapping table,
+		-- find authority from sys-user instead
+		SET @sys_user = SYSTEM_USER
+		SELECT		@authority_id = authority_id 
+		FROM		authority 
+		WHERE		identifier = @sys_user
+
+		-- IF THE ID IS NOT FOUND, TRY WITH THE DOMAIN NAME IN FRONT OF THE USER NAME.
+		IF @authority_id = -1
+		BEGIN
+			SELECT		@authority_id = authority_id 
+			FROM		authority 
+			WHERE		identifier = 'USER\' + @sys_user
+		END
+	END
+		
+	IF @authority_id = -1
+	BEGIN
+		RETURN -100
+	END
+
+	RETURN @authority_id
+END
+
+GO

--- a/database_objects/BookKeeping_devel_functions/dbo.fGetAuthorityIdFromSysUser.sql
+++ b/database_objects/BookKeeping_devel_functions/dbo.fGetAuthorityIdFromSysUser.sql
@@ -1,0 +1,43 @@
+USE [BookKeeping]
+GO
+/****** Object:  UserDefinedFunction [dbo].[fGetAuthorityIdFromSysUser]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE FUNCTION [dbo].[fGetAuthorityIdFromSysUser]() RETURNS INTEGER
+AS
+BEGIN
+	DECLARE @authority_id INTEGER 
+	SET @authority_id = -1
+	DECLARE @sys_user VARCHAR(255)
+	
+	SET @sys_user = SYSTEM_USER
+
+	-- PICKING OUT THE ID OF THE CURRENT USER
+	SELECT @authority_id = authority_id FROM authority WHERE
+	identifier = @sys_user
+
+	-- IF THE ID IS NOT FOUND, TRY WITH THE DOMAIN NAME IN FRONT OF THE USER NAME.
+	IF @authority_id = -1
+	BEGIN
+		SELECT @authority_id = authority_id FROM authority WHERE
+		identifier = 'USER\' + @sys_user
+	END
+	
+	IF @authority_id = -1
+	BEGIN
+		RETURN -100
+	END
+		
+	
+	RETURN @authority_id
+END
+
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/BookKeeping_devel_procedures.ssmssqlproj
+++ b/database_objects/BookKeeping_devel_procedures/BookKeeping_devel_procedures.ssmssqlproj
@@ -1,0 +1,399 @@
+<?xml version="1.0"?>
+<SqlWorkbenchSqlProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BookKeeping_devel_procedures">
+  <Items>
+    <LogicalFolder Name="Connections" Type="2" Sorted="true">
+      <Items />
+    </LogicalFolder>
+    <LogicalFolder Name="Queries" Type="0" Sorted="true">
+      <Items>
+        <FileNode Name="dbo.p_CleanAuthoritySessionMapping.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CleanAuthoritySessionMapping.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CompletePost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CompletePost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ConfirmPostArrival.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ConfirmPostArrival.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ConfirmPostOrdered.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ConfirmPostOrdered.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateArticleNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateArticleNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateArticleNumberNoSelect.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateArticleNumberNoSelect.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateCurrency.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateCurrency.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateCustomerNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateCustomerNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateInvoiceCategory.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateInvoiceCategory.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateMerchandise.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateMerchandise.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreatePost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreatePost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateSupplier.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateSupplier.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_CreateUser.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_CreateUser.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteArticleNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteArticleNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteCurrency.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteCurrency.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteCustomerNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteCustomerNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteInvoiceCategory.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteInvoiceCategory.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteMerchandise.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteMerchandise.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeletePost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeletePost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteSupplier.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteSupplier.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_DeleteUser.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_DeleteUser.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetArticleNumberById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetArticleNumberById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetArticleNumberByMerchandiseId.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetArticleNumberByMerchandiseId.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetArticleNumbers.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetArticleNumbers.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetColumnLength.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetColumnLength.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetCurrencies.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetCurrencies.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetCustomerNumberById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetCustomerNumberById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetCustomerNumberBySupplierId.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetCustomerNumberBySupplierId.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetCustomerNumbersAll.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetCustomerNumbersAll.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetInvoiceCategories.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetInvoiceCategories.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetInvoiceCategoryById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetInvoiceCategoryById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetMerchandise.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetMerchandise.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetMerchandiseById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetMerchandiseById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetPlaceOfPurchases.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetPlaceOfPurchases.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetPostById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetPostById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetPosts.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetPosts.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetPostsByCustomerNumberId.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetPostsByCustomerNumberId.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetSupplierById.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetSupplierById.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetSuppliers.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetSuppliers.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetTimeIntervalsForPosts.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetTimeIntervalsForPosts.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetUserCurrent.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetUserCurrent.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetUserFromBarcode.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetUserFromBarcode.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_GetUsers.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_GetUsers.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_OrderPost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_OrderPost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_RegretArrivalConfirmation.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_RegretArrivalConfirmation.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_RegretCompleted.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_RegretCompleted.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_RegretOrderConfirmed.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_RegretOrderConfirmed.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_RegretOrderPost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_RegretOrderPost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ReleaseAuthorityMapping.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ReleaseAuthorityMapping.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ResetArticleNumbersForMerchandise.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ResetArticleNumbersForMerchandise.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ResetPostInvoiceStatus.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ResetPostInvoiceStatus.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_ScheduledProcedureDisableProducts.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_ScheduledProcedureDisableProducts.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_SetAuthorityMappingFromBarcode.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_SetAuthorityMappingFromBarcode.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_SetAuthorityMappingFromSysUser.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_SetAuthorityMappingFromSysUser.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_SignPostInvoice.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_SignPostInvoice.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateArticleNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateArticleNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateCurrency.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateCurrency.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateCustomerNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateCustomerNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateInvoiceCategory.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateInvoiceCategory.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateMerchandise.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateMerchandise.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdatePost.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdatePost.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdatePostSalesOrderNumber.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdatePostSalesOrderNumber.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateSupplier.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateSupplier.StoredProcedure.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.p_UpdateUser.StoredProcedure.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.p_UpdateUser.StoredProcedure.sql</FullPath>
+        </FileNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Miscellaneous" Type="3" Sorted="true">
+      <Items />
+    </LogicalFolder>
+  </Items>
+</SqlWorkbenchSqlProject>

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CleanAuthoritySessionMapping.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CleanAuthoritySessionMapping.sql
@@ -1,0 +1,58 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CleanAuthoritySessionMapping]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CleanAuthoritySessionMapping]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @tmp as table(
+spid int,
+ecid int,
+status varchar(255),
+logname varchar(255),
+hostname varchar(255),
+blk bit,
+dbname varchar(255),
+cmd varchar(255),
+request_id int
+)
+
+insert into @tmp
+exec sp_who
+
+delete from authority_session_mapping
+where session_id not in (
+select t.spid as session_id from @tmp t
+	inner join sys.dm_exec_sessions es 
+	on t.spid = es.session_id
+where es.is_user_process = 1 and t.dbname = db_name())
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to clean authority mapping : %d', 15, 1)
+	RETURN
+END
+
+
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CompletePost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CompletePost.sql
@@ -1,0 +1,53 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CompletePost]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CompletePost](
+@id INTEGER,
+@arrival_sign INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @identifier VARCHAR(255)
+DECLARE @idString VARCHAR(15)
+DECLARE @idStringTmp VARCHAR(15)
+DECLARE @idStringLength INT
+
+SET @idStringLength = 15
+
+--Create identifier
+SET @idStringTmp = CAST(@id AS VARCHAR(15))
+SET @idString = REPLICATE('0', @idStringLength - LEN(@idStringTmp)) + @idStringTmp
+
+UPDATE post 
+SET 
+	arrival_sign = @arrival_sign,
+	arrival_date = GETDATE()
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ConfirmPostArrival.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ConfirmPostArrival.sql
@@ -1,0 +1,42 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ConfirmPostArrival]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_ConfirmPostArrival](
+@id INTEGER,
+@arrival_sign INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	arrival_sign = @arrival_sign,
+	arrival_date = GETDATE()
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ConfirmPostOrdered.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ConfirmPostOrdered.sql
@@ -1,0 +1,42 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ConfirmPostOrdered]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_ConfirmPostOrdered](
+@id INTEGER,
+@authority_id_confirmed_order INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	authority_id_confirmed_order = @authority_id_confirmed_order,
+	confirmed_order_date = GETDATE()
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateArticleNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateArticleNumber.sql
@@ -1,0 +1,57 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateArticleNumber]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CreateArticleNumber](
+@identifier VARCHAR(255),
+@merchandise_id INTEGER,
+@active bit = 1
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @id integer
+
+if @active = 1 
+-- Make all previous article numbers for this merchandise_id inactive
+begin
+UPDATE article_number SET active = 0 WHERE merchandise_id = @merchandise_id
+end
+
+INSERT INTO article_number
+(identifier,
+merchandise_id)
+VALUES
+(@identifier,
+@merchandise_id)
+
+set @id = scope_identity()
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create article number with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SELECT * from article_number_view where id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateArticleNumberNoSelect.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateArticleNumberNoSelect.sql
@@ -1,0 +1,55 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateArticleNumberNoSelect]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CreateArticleNumberNoSelect](
+@identifier VARCHAR(255),
+@merchandise_id INTEGER,
+@active bit = 1
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @id integer
+
+if @active = 1 
+-- Make all previous article numbers for this merchandise_id inactive
+begin
+UPDATE article_number SET active = 0 WHERE merchandise_id = @merchandise_id
+end
+
+INSERT INTO article_number
+(identifier,
+merchandise_id)
+VALUES
+(@identifier,
+@merchandise_id)
+
+set @id = scope_identity()
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create article number with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateCurrency.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateCurrency.sql
@@ -1,0 +1,54 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateCurrency]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CreateCurrency](
+@identifier VARCHAR(255) = NULL,
+@currency_code VARCHAR(3) = NULL,
+@symbol nvarchar(20) = NULL
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @currency_id INT
+
+INSERT INTO currency
+(identifier,
+currency_code,
+symbol)
+VALUES
+(@identifier,
+@currency_code,
+@symbol
+)
+
+SET @currency_id = SCOPE_IDENTITY()
+
+SELECT 
+	currency_id,
+	symbol,
+	identifier,
+	currency_code
+FROM currency
+WHERE currency_id = @currency_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateCustomerNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateCustomerNumber.sql
@@ -1,0 +1,49 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateCustomerNumber]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_CreateCustomerNumber](
+	@identifier VARCHAR(255),
+	@description varchar(255),
+	@supplier_id int,
+	@place_of_purchase varchar(30),
+	@enabled bit = 1
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @place_of_purchase_id int
+
+
+select @place_of_purchase_id = place_of_purchase_id
+from place_of_purchase 
+where code = @place_of_purchase
+
+insert into customer_number
+(identifier, description, supplier_id, place_of_purchase_id, enabled)
+values
+(@identifier, @description, @supplier_id, @place_of_purchase_id, @enabled)
+
+SELECT 
+	customer_number_id as id,
+	identifier,
+	description,
+	supplier_id,
+	pop.code as place_of_purchase,
+	enabled
+FROM customer_number cn
+	inner join place_of_purchase pop on pop.place_of_purchase_id = cn.place_of_purchase_id
+where customer_number_id = SCOPE_IDENTITY()
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateInvoiceCategory.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateInvoiceCategory.sql
@@ -1,0 +1,62 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateInvoiceCategory]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CreateInvoiceCategory](
+@identifier VARCHAR(255),
+@number INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @invoice_category_id INTEGER
+
+INSERT INTO invoice_category
+(identifier,
+number
+)
+VALUES
+(@identifier,
+@number
+)
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create invoice category with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET @invoice_category_id = NULL
+SELECT @invoice_category_id = invoice_category_id FROM invoice_category WHERE identifier = @identifier
+IF @invoice_category_id IS NULL
+BEGIN
+	RAISERROR('invoice_category_id for invoice_category was not found', 15, 1)
+	RETURN
+END
+
+SELECT 
+invoice_category_id as id,
+identifier,
+number
+FROM invoice_category WHERE invoice_category_id = @invoice_category_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateMerchandise.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateMerchandise.sql
@@ -1,0 +1,89 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateMerchandise]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_CreateMerchandise](
+@identifier VARCHAR(255),
+@comment VARCHAR(1024) = null,
+@supplier_id INTEGER = NULL,
+@amount VARCHAR(255),
+@appr_prize MONEY,
+@storage VARCHAR(255) = null,
+@article_number VARCHAR(255) = NULL,
+@category VARCHAR(255) = null,
+@invoice_category_id INTEGER = NULL,
+@currency_id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @merchandise_id1 INTEGER
+
+INSERT INTO merchandise
+(identifier,
+supplier_id,
+comment,
+amount,
+appr_prize,
+storage,
+category,
+invoice_category_id,
+currency_id)
+VALUES
+(@identifier,
+@supplier_id,
+@comment,
+@amount,
+@appr_prize,
+@storage,
+@category,
+@invoice_category_id,
+@currency_id)
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create merchandise with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET @merchandise_id1 = NULL
+SELECT @merchandise_id1 = merchandise_id FROM merchandise WHERE identifier = @identifier
+IF @merchandise_id1 IS NULL
+BEGIN
+	RAISERROR('merchandise_id for merchandise was not found', 15, 1)
+	RETURN
+END
+
+IF @article_number = NULL
+BEGIN
+	SET @article_number = "";
+END
+
+if not @article_number = ""
+begin
+	EXECUTE p_CreateArticleNumberNoSelect @identifier = @article_number, @merchandise_id = @merchandise_id1
+end
+
+select * from merchandise_view 
+WHERE id = @merchandise_id1
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreatePost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreatePost.sql
@@ -1,0 +1,101 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreatePost]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_CreatePost](
+@article_number_id int = null,
+@authority_id_booker INTEGER,
+@comment VARCHAR(1024) = NULL,
+@merchandise_id INTEGER,
+@supplier_id INTEGER = NULL,
+@amount VARCHAR(255) = NULL,
+@appr_prize MONEY = NULL,
+@currency_id INTEGER,
+@invoice_inst BIT = NULL,
+@invoice_clin BIT = NULL,
+@invoice_absent BIT = NULL,
+@invoice_number varchar(255) = null,
+@final_prize money = null,
+@delivery_deviation varchar(1024) = null,
+@purchase_order_no varchar(255) = null,
+@sales_order_no varchar(255) = null,
+@place_of_purchase varchar(30),
+@customer_number_id int = null)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @post_id INTEGER
+declare @place_of_purchase_id int
+
+select @place_of_purchase_id = place_of_purchase_id 
+from place_of_purchase 
+where code = @place_of_purchase
+
+INSERT INTO post
+	(
+		article_number_id,
+		comment,
+		authority_id_booker,
+		book_date,
+		merchandise_id,
+		supplier_id,
+		appr_prize,
+		amount,
+		currency_id,
+		invoice_inst,
+		invoice_clin,
+		invoice_absent,
+		invoice_number,
+		final_prize,
+		delivery_deviation,
+		purchase_order_no,
+		sales_order_no,
+		place_of_purchase_id,
+		customer_number_id
+	)
+VALUES
+	(
+		@article_number_id,
+		@comment,
+		@authority_id_booker,
+		GETDATE(),
+		@merchandise_id,
+		@supplier_id,
+		@appr_prize,
+		@amount,
+		@currency_id,
+		@invoice_inst,
+		@invoice_clin,
+		@invoice_absent,
+		@invoice_number,
+		@final_prize,
+		@delivery_deviation,
+		@purchase_order_no,
+		@sales_order_no,
+		@place_of_purchase_id,
+		@customer_number_id
+	)
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create order post', 15, 1)
+	RETURN
+END
+
+select * from post_view
+WHERE id = SCOPE_IDENTITY()
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateSupplier.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateSupplier.sql
@@ -1,0 +1,65 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateSupplier]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_CreateSupplier](
+@identifier VARCHAR(255),
+@short_name VARCHAR(255),
+@comment VARCHAR(1024),
+@tel_nr VARCHAR(30),
+@contract_terminate VARCHAR(255)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @supplier_id INTEGER
+
+INSERT INTO supplier
+(identifier,
+short_name,
+comment,
+tel_nr,
+contract_terminate)
+VALUES
+(@identifier,
+@short_name,
+@comment,
+@tel_nr,
+@contract_terminate)
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create supplier with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET @supplier_id = NULL
+SELECT @supplier_id = supplier_id FROM supplier WHERE identifier = @identifier
+IF @supplier_id IS NULL
+BEGIN
+	RAISERROR('supplier_id for supplier was not found', 15, 1)
+	RETURN
+END
+
+SELECT 
+supplier_id as id,
+identifier,
+short_name,
+comment,
+tel_nr,
+contract_terminate,
+enabled
+FROM supplier WHERE supplier_id = @supplier_id
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_CreateUser.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_CreateUser.sql
@@ -1,0 +1,59 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_CreateUser]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+CREATE PROCEDURE [dbo].[p_CreateUser](
+@identifier VARCHAR(255),
+@name VARCHAR(255),
+@account_status BIT,
+@comment VARCHAR(1024) = NULL,
+@user_type VARCHAR(32),
+@place_of_purchase varchar(30)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+declare @place_of_purchase_id int
+
+select @place_of_purchase_id = place_of_purchase_id 
+from place_of_purchase 
+where code = @place_of_purchase
+
+
+-- Get current user
+INSERT INTO authority
+(identifier,
+name,
+account_status,
+comment,
+user_type,
+place_of_purchase_id)
+VALUES
+(@identifier,
+@name,
+@account_status,
+@comment,
+@user_type,
+@place_of_purchase_id)
+
+SELECT 
+	authority_id AS id,
+	identifier,
+	name,
+	account_status,
+	user_type,
+	pop.code as place_of_purchase,
+	comment
+FROM authority a
+	inner join place_of_purchase pop on pop.place_of_purchase_id = a.place_of_purchase_id
+WHERE identifier = @identifier
+
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteArticleNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteArticleNumber.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteArticleNumber]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeleteArticleNumber](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM article_number WHERE article_number_id = @id
+
+SET NOCOUNT OFF
+END 
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteCurrency.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteCurrency.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteCurrency]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeleteCurrency](
+@currency_id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM currency WHERE currency_id = @currency_id
+
+SET NOCOUNT OFF
+END 
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteCustomerNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteCustomerNumber.sql
@@ -1,0 +1,24 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteCustomerNumber]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_DeleteCustomerNumber](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM customer_number WHERE customer_number_id = @id
+
+SET NOCOUNT OFF
+END 
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteInvoiceCategory.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteInvoiceCategory.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteInvoiceCategory]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeleteInvoiceCategory](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM invoice_category WHERE invoice_category_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteMerchandise.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteMerchandise.sql
@@ -1,0 +1,34 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteMerchandise]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeleteMerchandise](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM article_number WHERE merchandise_id = @id
+
+DELETE FROM merchandise WHERE merchandise_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeletePost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeletePost.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeletePost]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeletePost](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM post WHERE post_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteSupplier.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteSupplier.sql
@@ -1,0 +1,26 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteSupplier]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_DeleteSupplier](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+delete from customer_number where supplier_id = @id
+
+DELETE FROM supplier WHERE supplier_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteUser.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_DeleteUser.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_DeleteUser]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_DeleteUser](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DELETE FROM authority WHERE authority_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumberById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumberById.sql
@@ -1,0 +1,34 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetArticleNumberById]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetArticleNumberById]
+(
+	@id int
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+select * from article_number_view 
+WHERE id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumberByMerchandiseId.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumberByMerchandiseId.sql
@@ -1,0 +1,34 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetArticleNumberByMerchandiseId]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetArticleNumberByMerchandiseId]
+(
+	@merchandise_id int
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+select * from article_number_view 
+WHERE merchandise_id = @merchandise_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumbers.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetArticleNumbers.sql
@@ -1,0 +1,30 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetArticleNumbers]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetArticleNumbers]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT * FROM article_number_view
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetColumnLength.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetColumnLength.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetColumnLength]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetColumnLength] (
+	@table VARCHAR(255),
+	@column VARCHAR(255))
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT COL_LENGTH(@table, @column) AS 'column_length'
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetCurrencies.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetCurrencies.sql
@@ -1,0 +1,35 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetCurrencies]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetCurrencies]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT
+	currency_id,
+	symbol,
+	identifier,
+	currency_code
+FROM currency
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumberById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumberById.sql
@@ -1,0 +1,35 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetCustomerNumberById]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_GetCustomerNumberById](
+	@id int
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+	cn.customer_number_id as id,
+	cn.identifier,
+	cn.description,
+	cn.supplier_id,
+	pop.code as place_of_purchase,
+	cn.enabled
+from customer_number cn
+	inner join place_of_purchase pop on cn.place_of_purchase_id = pop.place_of_purchase_id
+where customer_number_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumberBySupplierId.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumberBySupplierId.sql
@@ -1,0 +1,35 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetCustomerNumberBySupplierId]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_GetCustomerNumberBySupplierId](
+	@supplier_id int
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+	cn.customer_number_id as id,
+	cn.identifier,
+	cn.description,
+	cn.supplier_id,
+	pop.code as place_of_purchase,
+	cn.enabled
+from customer_number cn
+	inner join place_of_purchase pop on cn.place_of_purchase_id = pop.place_of_purchase_id
+where supplier_id = @supplier_id
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumbersAll.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetCustomerNumbersAll.sql
@@ -1,0 +1,30 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetCustomerNumbersAll]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_GetCustomerNumbersAll]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+	cn.customer_number_id as id,
+	cn.identifier,
+	cn.description,
+	cn.supplier_id,
+	pop.code as place_of_purchase,
+	cn.enabled
+from customer_number cn
+	inner join place_of_purchase pop on cn.place_of_purchase_id = pop.place_of_purchase_id
+
+SET NOCOUNT OFF
+END 
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetInvoiceCategories.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetInvoiceCategories.sql
@@ -1,0 +1,35 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetInvoiceCategories]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetInvoiceCategories]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+invoice_category_id as id,
+identifier,
+number
+FROM invoice_category
+ORDER BY identifier ASC
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetInvoiceCategoryById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetInvoiceCategoryById.sql
@@ -1,0 +1,37 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetInvoiceCategoryById]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetInvoiceCategoryById](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT
+	invoice_category_id AS id,
+	identifier,
+	number
+FROM invoice_category
+WHERE invoice_category_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetMerchandise.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetMerchandise.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetMerchandise]    Script Date: 7/27/2017 1:42:17 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetMerchandise]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+select * from merchandise_view 
+ORDER BY ISNULL(supplier_identifier, '000') ASC, identifier ASC
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetMerchandiseById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetMerchandiseById.sql
@@ -1,0 +1,33 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetMerchandiseById]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetMerchandiseById](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+select * from merchandise_view
+WHERE id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetPlaceOfPurchases.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetPlaceOfPurchases.sql
@@ -1,0 +1,29 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetPlaceOfPurchases]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetPlaceOfPurchases]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT place_of_purchase_id, code
+from place_of_purchase
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetPostById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetPostById.sql
@@ -1,0 +1,26 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetPostById]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_GetPostById](
+@id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT * from post_view
+WHERE id = @id
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetPosts.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetPosts.sql
@@ -1,0 +1,29 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetPosts]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_GetPosts](
+@booker_from_date DATETIME = NULL,
+@time_restriction_to_completed_posts BIT
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+select * from post_view 
+WHERE book_date > ISNULL(@booker_from_date, 0) OR 
+(@time_restriction_to_completed_posts = 1 AND invoice_status = 'Incoming')
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetPostsByCustomerNumberId.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetPostsByCustomerNumberId.sql
@@ -1,0 +1,26 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetPostsByCustomerNumberId]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_GetPostsByCustomerNumberId](
+@customer_number_id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT * from post_view
+WHERE customer_number_id = @customer_number_id
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetSupplierById.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetSupplierById.sql
@@ -1,0 +1,32 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetSupplierById]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_GetSupplierById](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+	supplier_id AS id,
+	identifier,
+	short_name,
+	enabled,
+	comment,
+	tel_nr,
+	contract_terminate
+FROM supplier WHERE supplier_id = @id
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetSuppliers.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetSuppliers.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetSuppliers]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_GetSuppliers]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT 
+	supplier_id AS id,
+	identifier,
+	short_name,
+	enabled,
+	comment,
+	tel_nr,
+	contract_terminate
+FROM supplier
+ORDER BY identifier ASC
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetTimeIntervalsForPosts.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetTimeIntervalsForPosts.sql
@@ -1,0 +1,34 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetTimeIntervalsForPosts]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetTimeIntervalsForPosts]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+SELECT
+description,
+months
+FROM time_intervals_for_posts
+ORDER BY months ASC
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetUserCurrent.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetUserCurrent.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetUserCurrent]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetUserCurrent]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+-- Get current user
+SELECT * 
+from authority_view
+WHERE id = dbo.fGetAuthorityId()
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetUserFromBarcode.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetUserFromBarcode.sql
@@ -1,0 +1,33 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetUserFromBarcode]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetUserFromBarcode](
+@chiasma_barcode varchar(255)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+-- Get current user
+SELECT *
+from authority_view
+WHERE chiasma_barcode = @chiasma_barcode
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_GetUsers.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_GetUsers.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_GetUsers]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_GetUsers]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+-- Get users
+SELECT * 
+from authority_view
+ORDER BY name ASC
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_OrderPost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_OrderPost.sql
@@ -1,0 +1,42 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_OrderPost]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_OrderPost](
+@id INTEGER,
+@authority_id_orderer INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	authority_id_orderer = @authority_id_orderer,
+	order_date = GETDATE()
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_RegretArrivalConfirmation.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_RegretArrivalConfirmation.sql
@@ -1,0 +1,44 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_RegretArrivalConfirmation]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_RegretArrivalConfirmation](
+@id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	arrival_date = NULL,
+	arrival_sign = NULL,
+	invoice_status = 'Incoming',
+	authority_id_invoicer = NULL,
+	invoice_date = NULL
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_RegretCompleted.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_RegretCompleted.sql
@@ -1,0 +1,43 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_RegretCompleted]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_RegretCompleted](
+@id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	invoice_status = 'Incoming',
+	authority_id_invoicer = NULL,
+	invoice_absent = 0,
+	invoice_date = NULL
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_RegretOrderConfirmed.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_RegretOrderConfirmed.sql
@@ -1,0 +1,46 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_RegretOrderConfirmed]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_RegretOrderConfirmed](
+@id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	authority_id_confirmed_order = null,
+	confirmed_order_date = null,
+	arrival_date = NULL,
+	arrival_sign = NULL,
+	invoice_status = 'Incoming',
+	authority_id_invoicer = NULL,
+	invoice_date = NULL
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_RegretOrderPost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_RegretOrderPost.sql
@@ -1,0 +1,46 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_RegretOrderPost]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_RegretOrderPost](
+@id INTEGER)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	authority_id_orderer = NULL,
+	order_date = NULL,
+	arrival_date = NULL,
+	arrival_sign = NULL,
+	invoice_status = 'Incoming',
+	authority_id_invoicer = NULL,
+	invoice_date = NULL
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ReleaseAuthorityMapping.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ReleaseAuthorityMapping.sql
@@ -1,0 +1,41 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ReleaseAuthorityMapping]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_ReleaseAuthorityMapping]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+-- Remove row from authority_session_mapping table
+-- with session_id matching @@spid
+
+delete from authority_session_mapping 
+where session_id = @@spid
+
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed release authority mapping with session id: %d', 15, 1, @@spid)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ResetArticleNumbersForMerchandise.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ResetArticleNumbersForMerchandise.sql
@@ -1,0 +1,40 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ResetArticleNumbersForMerchandise]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_ResetArticleNumbersForMerchandise](
+@merchandise_id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+update article_number set
+active = 0
+where merchandise_id = @merchandise_id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update article number for merchandise with id: %s', 15, 1, @merchandise_id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ResetPostInvoiceStatus.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ResetPostInvoiceStatus.sql
@@ -1,0 +1,54 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ResetPostInvoiceStatus]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_ResetPostInvoiceStatus](
+@id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @identifier VARCHAR(255)
+
+
+UPDATE post 
+SET 
+	authority_id_invoicer = NULL,
+	invoice_date = NULL,
+	invoice_status = 'Incoming',
+	authority_id_orderer = NULL,
+	order_date = NULL,
+	predicted_arrival = NULL,
+	invoice_inst = 0,
+	invoice_clin = 0,
+	arrival_date = NULL,
+	arrival_sign = NULL,
+	invoice_absent = 0
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_ScheduledProcedureDisableProducts.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_ScheduledProcedureDisableProducts.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_ScheduledProcedureDisableProducts]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+CREATE PROCEDURE [dbo].[p_ScheduledProcedureDisableProducts]
+AS
+BEGIN
+
+SET NOCOUNT ON
+
+
+-- SELECT satserna:
+-- Lista alla produkter som är kopplade till en post, där någon av posterna är nyare än 1 år 
+-- Lista alla produkter som inte är kopplade till en post, och som är skapade inom ett år
+update m set enabled = 0 from merchandise m where m.enabled = 1 and m.merchandise_id not in
+(select merchandise_id from post group by post_id, book_date, merchandise_id 
+having getdate() < dateadd(month, 18, max(book_date))
+union 
+select m.merchandise_id from merchandise m inner join merchandise_history mh on 
+m.merchandise_id = mh.merchandise_id where mh.changed_action = 'i' and
+getdate() < dateadd(month, 18, mh.changed_date))
+
+end
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_SetAuthorityMappingFromBarcode.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_SetAuthorityMappingFromBarcode.sql
@@ -1,0 +1,95 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_SetAuthorityMappingFromBarcode]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_SetAuthorityMappingFromBarcode](
+	@chiasma_barcode varchar(255)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @authority_id int
+declare @old_authority_id int
+declare @session_id smallint
+
+select	@authority_id = authority_id 
+from	authority
+where	chiasma_barcode = @chiasma_barcode
+
+if isnull(@authority_id, -1) = -1
+begin
+	raiserror('Barcode %d could not be linked to a user!', 15, 1, @chiasma_barcode)
+	return
+end
+
+-- Get process id for this session
+
+set @session_id = @@spid
+
+if isnull(@session_id, -1) = -1
+begin
+	raiserror('Session id could not be retrieved', 15, 1)
+	return
+end
+
+-- Update authority_mapping
+select	@old_authority_id = authority_id 
+from	authority_session_mapping 
+where	session_id = @session_id
+
+
+-- First check if the session id already exists in the authority_session-mapping table,
+-- if so, update the table and write a row in the conflict row
+-- else, insert a new row in the authority_session_mapping table
+if not isnull(@old_authority_id, -1) = -1
+begin
+	insert into authority_session_conflict_logg
+	(conflict_date, old_authority_id, new_authority_id, session_id)
+	values
+	(getdate(), @old_authority_id, @authority_id, @session_id)
+
+	update	authority_session_mapping 
+	set
+			session_id = @session_id,
+			authority_id = @authority_id
+	where	session_id = @session_id
+end
+else
+begin
+	insert into		authority_session_mapping
+					(session_id, authority_id)
+	values			(@session_id, @authority_id)
+end
+
+
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to set authority mapping with barcode: %d', 15, 1, @chiasma_barcode)
+	RETURN
+END
+
+select	authority_id 
+from	authority_session_mapping
+where	session_id = @session_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_SetAuthorityMappingFromSysUser.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_SetAuthorityMappingFromSysUser.sql
@@ -1,0 +1,80 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_SetAuthorityMappingFromSysUser]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_SetAuthorityMappingFromSysUser]
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @old_authority_id int
+declare @session_id int
+
+-- Get process id for this session
+set @session_id = @@spid
+
+if isnull(@session_id, -1) = -1
+begin
+	raiserror('Session id could not be retrieved', 15, 1)
+	return
+end
+
+-- Update authority_mapping
+select	@old_authority_id = authority_id 
+from	authority_session_mapping 
+where	session_id = @session_id
+
+
+-- First check if the session id already exists in the authority_session-mapping table,
+-- if so, update the table and write a row in the conflict row
+-- else, insert a new row in the authority_session_mapping table
+if not isnull(@old_authority_id, -1) = -1
+begin
+	insert into authority_session_conflict_logg
+	(conflict_date, old_authority_id, new_authority_id, session_id)
+	values
+	(getdate(), @old_authority_id, dbo.fGetAuthorityIdFromSysUser(), @session_id)
+
+	update	authority_session_mapping 
+	set		session_id = @session_id,
+			authority_id = dbo.fGetAuthorityIdFromSysUser()
+	where	session_id = @session_id
+end
+else
+begin
+	insert into		authority_session_mapping
+					(session_id, authority_id)
+	values			(@session_id, dbo.fGetAuthorityIdFromSysUser())
+end
+
+
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to set authority mapping from sys user', 15, 1)
+	RETURN
+END
+
+select authority_id 
+from authority_session_mapping
+where session_id = @session_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_SignPostInvoice.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_SignPostInvoice.sql
@@ -1,0 +1,41 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_SignPostInvoice]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_SignPostInvoice](
+@id INTEGER,
+@authority_id_invoicer INTEGER,
+@invoice_status VARCHAR(20),
+@invoice_absent BIT
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	authority_id_invoicer = @authority_id_invoicer,
+	invoice_date = GETDATE(),
+	invoice_status = @invoice_status,
+	invoice_absent = @invoice_absent
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateArticleNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateArticleNumber.sql
@@ -1,0 +1,52 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateArticleNumber]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateArticleNumber](
+@id INTEGER,
+@identifier VARCHAR(255) = null,
+@merchandise_id integer = null,
+@active bit
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+if @active = 1 and not isnull(@merchandise_id, 0) = 0
+begin
+	update article_number set
+	active = 0
+	where merchandise_id = @merchandise_id
+end
+
+UPDATE article_number SET
+identifier = @identifier,
+merchandise_id = @merchandise_id,
+active = @active
+WHERE article_number_id = @id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update article number with id: %s', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateCurrency.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateCurrency.sql
@@ -1,0 +1,39 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateCurrency]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateCurrency](
+@currency_id INTEGER,
+@identifier VARCHAR(255) = NULL,
+@currency_code VARCHAR(3) = NULL,
+@symbol NVARCHAR(20) = NULL
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE currency SET
+identifier = @identifier,
+currency_code = @currency_code,
+symbol = @symbol
+WHERE currency_id = @currency_id
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateCustomerNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateCustomerNumber.sql
@@ -1,0 +1,48 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateCustomerNumber]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateCustomerNumber](
+@id INTEGER,
+@identifier VARCHAR(255),
+@description varchar(255),
+@place_of_purchase VARCHAR(30),
+@supplier_id int,
+@enabled bit
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+declare @place_of_purchase_id int
+
+select @place_of_purchase_id = place_of_purchase_id
+from place_of_purchase where code = @place_of_purchase
+
+update customer_number set
+	identifier = @identifier,
+	description = @description,
+	place_of_purchase_id = @place_of_purchase_id,
+	supplier_id = @supplier_id,
+	enabled = @enabled
+where customer_number_id = @id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update customer number with id: %s', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateInvoiceCategory.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateInvoiceCategory.sql
@@ -1,0 +1,43 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateInvoiceCategory]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateInvoiceCategory](
+@id INTEGER,
+@identifier VARCHAR(255),
+@number INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE invoice_category
+SET identifier = @identifier,
+	number = @number
+WHERE invoice_category_id = @id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update invoice category with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateMerchandise.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateMerchandise.sql
@@ -1,0 +1,57 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateMerchandise]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateMerchandise](
+@id INTEGER,
+@identifier VARCHAR(255),
+@comment VARCHAR(1024),
+@supplier_id INTEGER = NULL,
+@amount VARCHAR(255),
+@appr_prize MONEY,
+@storage VARCHAR(255),
+@enabled BIT,
+@invoice_category_id INTEGER = NULL,
+@currency_id INTEGER
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE merchandise SET
+identifier = @identifier,
+supplier_id = @supplier_id,
+enabled = @enabled,
+comment = @comment,
+amount = @amount,
+appr_prize = @appr_prize,
+storage = @storage,
+invoice_category_id = @invoice_category_id,
+currency_id = @currency_id
+WHERE merchandise_id = @id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to create merchandise with identifier: %s', 15, 1, @identifier)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdatePost.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdatePost.sql
@@ -1,0 +1,96 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdatePost]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdatePost](
+@id INTEGER,
+@comment VARCHAR(1024) = NULL,
+@appr_prize MONEY = NULL,
+@amount VARCHAR(255) = NULL,
+@invoice_clin BIT,
+@invoice_inst BIT,
+@predicted_arrival VARCHAR(255) = NULL,
+@invoice_status VARCHAR(20),
+@invoice_absent BIT,
+@currency_id INTEGER,
+@authority_id_booker INTEGER,
+@book_date DATETIME,
+@authority_id_orderer INTEGER = NULL,
+@order_date DATETIME = NULL,
+@arrival_sign INTEGER = NULL,
+@arrival_date DATETIME = NULL,
+@authority_id_invoicer INTEGER = NULL,
+@invoice_date DATETIME = NULL,
+@article_number_id INTEGER = null,
+@supplier_id integer = null,
+@invoice_number varchar(255) = null,
+@final_prize money = null,
+@authority_id_confirmed_order varchar(255) = null,
+@confirmed_order_date datetime = null,
+@delivery_deviation varchar(1024) = null,
+@purchase_order_no varchar(255) = null,
+@sales_order_no varchar(255) = null,
+@place_of_purchase varchar(30),
+@customer_number_id int = null)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+
+DECLARE @appr_arrival_dt DATETIME
+
+SET @appr_arrival_dt = CONVERT(DATETIME, @predicted_arrival)
+
+
+UPDATE post 
+SET 
+	comment = @comment,
+	appr_prize = @appr_prize,
+	amount = @amount,
+	invoice_clin = @invoice_clin,
+	invoice_inst = @invoice_inst,
+	predicted_arrival = @appr_arrival_dt,
+	invoice_status = @invoice_status,
+	invoice_absent = @invoice_absent,
+	currency_id = @currency_id,
+	authority_id_booker = @authority_id_booker,
+	book_date = @book_date,
+	authority_id_orderer = @authority_id_orderer,
+	order_date = @order_date,
+	arrival_sign = @arrival_sign,
+	arrival_date = @arrival_date,
+	authority_id_invoicer = @authority_id_invoicer,
+	invoice_date = @invoice_date,
+	article_number_id = @article_number_id,
+	supplier_id = @supplier_id,
+	invoice_number = @invoice_number,
+	final_prize = @final_prize,
+	authority_id_confirmed_order = @authority_id_confirmed_order,
+	confirmed_order_date = @confirmed_order_date,
+	delivery_deviation = @delivery_deviation,
+	purchase_order_no = @purchase_order_no,
+	sales_order_no = @sales_order_no,
+	place_of_purchase_id = pop.place_of_purchase_id,
+	customer_number_id = @customer_number_id
+FROM place_of_purchase pop 
+WHERE post_id = @id AND	pop.code = @place_of_purchase
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdatePostSalesOrderNumber.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdatePostSalesOrderNumber.sql
@@ -1,0 +1,34 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdatePostSalesOrderNumber]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_UpdatePostSalesOrderNumber](
+@id INTEGER,
+@sales_order_no varchar(255)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE post 
+SET 
+	sales_order_no = @sales_order_no
+WHERE post_id = @id
+	
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update post with id:', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateSupplier.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateSupplier.sql
@@ -1,0 +1,43 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateSupplier]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+CREATE PROCEDURE [dbo].[p_UpdateSupplier](
+@id INTEGER,
+@identifier VARCHAR(255),
+@short_name VARCHAR(255),
+@enabled BIT,
+@comment VARCHAR(1024),
+@tel_nr VARCHAR(30),
+@contract_terminate VARCHAR(255)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+UPDATE supplier SET
+identifier = @identifier,
+short_name = @short_name,
+enabled = @enabled,
+comment = @comment,
+tel_nr = @tel_nr,
+contract_terminate = @contract_terminate
+WHERE supplier_id = @id
+
+IF @@ERROR <> 0
+BEGIN
+	RAISERROR('Failed to update supplier with id: %s', 15, 1, @id)
+	RETURN
+END
+
+SET NOCOUNT OFF
+END
+
+
+GO

--- a/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateUser.sql
+++ b/database_objects/BookKeeping_devel_procedures/dbo.p_UpdateUser.sql
@@ -1,0 +1,45 @@
+USE [BookKeeping]
+GO
+/****** Object:  StoredProcedure [dbo].[p_UpdateUser]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+
+
+
+CREATE PROCEDURE [dbo].[p_UpdateUser](
+@id INTEGER,
+@identifier VARCHAR(255),
+@name VARCHAR(255),
+@account_status BIT,
+@comment VARCHAR(1024) = NULL,
+@user_type VARCHAR(32),
+@place_of_purchase varchar(30)
+)
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+-- Get current user
+UPDATE authority SET
+identifier = @identifier,
+name = @name,
+account_status = @account_status,
+comment = @comment,
+user_type = @user_type,
+place_of_purchase_id = pop.place_of_purchase_id
+from place_of_purchase pop 
+WHERE authority_id = @id and pop.code = @place_of_purchase
+
+SET NOCOUNT OFF
+END
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_roles/BookKeeping_devel_roles.ssmssqlproj
+++ b/database_objects/BookKeeping_devel_roles/BookKeeping_devel_roles.ssmssqlproj
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<SqlWorkbenchSqlProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BookKeeping_devel_roles">
+  <Items>
+    <LogicalFolder Name="Connections" Type="2" Sorted="true">
+      <Items>
+        <ConnectionNode Name="MM-WCHS001:devel_edvard">
+          <Created>2017-07-27T14:20:09.2869947+02:00</Created>
+          <Type>SQL</Type>
+          <Server>MM-WCHS001</Server>
+          <UserName>devel_edvard</UserName>
+          <Authentication>SQL</Authentication>
+          <InitialDB>BookKeeping</InitialDB>
+          <LoginTimeout>15</LoginTimeout>
+          <ExecutionTimeout>0</ExecutionTimeout>
+          <ConnectionProtocol>NotSpecified</ConnectionProtocol>
+          <ApplicationName>Microsoft SQL Server Management Studio - Query</ApplicationName>
+        </ConnectionNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Queries" Type="0" Sorted="true">
+      <Items>
+        <FileNode Name="GrantExecute.sql">
+          <AssociatedConnectionMoniker>8c91a03d-f9b4-46c0-a305-b5dcc79ff907:MM-WCHS001:False:devel_edvard</AssociatedConnectionMoniker>
+          <AssociatedConnSrvName>MM-WCHS001</AssociatedConnSrvName>
+          <AssociatedConnUserName>devel_edvard</AssociatedConnUserName>
+          <FullPath>GrantExecute.sql</FullPath>
+        </FileNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Miscellaneous" Type="3" Sorted="true">
+      <Items />
+    </LogicalFolder>
+  </Items>
+</SqlWorkbenchSqlProject>

--- a/database_objects/BookKeeping_devel_roles/GrantExecute.sql
+++ b/database_objects/BookKeeping_devel_roles/GrantExecute.sql
@@ -1,0 +1,9 @@
+--List all functions and stored procedures by using:
+--
+USE BookKeeping_devel
+
+SELECT 'GRANT EXECUTE ON ' + name + ' TO BKuser'
+FROM sys.all_objects
+WHERE is_ms_shipped = 0
+AND (type = 'P' or type = 'FN')
+ORDER BY name

--- a/database_objects/BookKeeping_devel_triggers/BookKeeping_devel_triggers.ssmssqlproj
+++ b/database_objects/BookKeeping_devel_triggers/BookKeeping_devel_triggers.ssmssqlproj
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<SqlWorkbenchSqlProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BookKeeping_devel_triggers">
+  <Items>
+    <LogicalFolder Name="Connections" Type="2" Sorted="true">
+      <Items />
+    </LogicalFolder>
+    <LogicalFolder Name="Queries" Type="0" Sorted="true">
+      <Items>
+        <FileNode Name="T_article_number_delete.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_article_number_delete.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_article_number_insert_update.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_article_number_insert_update.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_merchandise_delete.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_merchandise_delete.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_merchandise_insert_update.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_merchandise_insert_update.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_post_delete.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_post_delete.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_post_insert_update.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_post_insert_update.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_supplier_delete.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_supplier_delete.sql</FullPath>
+        </FileNode>
+        <FileNode Name="T_supplier_insert_update.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>T_supplier_insert_update.sql</FullPath>
+        </FileNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Miscellaneous" Type="3" Sorted="true">
+      <Items />
+    </LogicalFolder>
+  </Items>
+</SqlWorkbenchSqlProject>

--- a/database_objects/BookKeeping_devel_triggers/T_article_number_delete.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_article_number_delete.sql
@@ -1,0 +1,27 @@
+USE [BookKeeping]
+GO
+CREATE TRIGGER [dbo].[T_article_number_delete] ON [dbo].[article_number]
+AFTER DELETE
+
+AS
+BEGIN 
+SET NOCOUNT ON
+
+INSERT INTO article_number_history
+	(article_number_id,
+	 identifier,
+	 merchandise_id,
+	 active, 
+	 changed_action)
+SELECT
+	 article_number_id,
+	 identifier,
+	 merchandise_id,
+	 active,      
+     'D'
+FROM deleted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_article_number_insert_update.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_article_number_insert_update.sql
@@ -1,0 +1,31 @@
+USE [BookKeeping]
+
+CREATE TRIGGER [dbo].[T_article_number_insert_update] ON [dbo].[article_number]
+AFTER INSERT, UPDATE
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @action CHAR(1)
+
+IF EXISTS(SELECT * FROM deleted) SET @action = 'U' ELSE SET @action = 'I'
+
+INSERT INTO article_number_history
+	(article_number_id,
+	 identifier,
+	 merchandise_id,
+	 active, 
+	 changed_action)
+SELECT
+	 article_number_id,
+	 identifier,
+	 merchandise_id,
+	 active,      
+	 @action
+FROM inserted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_merchandise_delete.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_merchandise_delete.sql
@@ -1,0 +1,41 @@
+USE [BookKeeping]
+GO
+CREATE TRIGGER [dbo].[T_merchandise_delete] ON [dbo].[merchandise]
+AFTER DELETE
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+INSERT INTO merchandise_history
+	(merchandise_id,
+	 identifier,
+	 supplier_id,
+	 enabled, 
+	 comment,
+	 amount,
+	 appr_prize,
+	 storage,
+	 category,
+	 invoice_category_id,
+	 currency_id,
+	 changed_action)
+SELECT
+	 merchandise_id,
+	 identifier,
+	 supplier_id,
+	 enabled, 
+	 comment,
+	 amount,
+	 appr_prize,
+	 storage,
+	 category,
+	 invoice_category_id,
+	 currency_id,
+     'D'
+FROM deleted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_merchandise_insert_update.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_merchandise_insert_update.sql
@@ -1,0 +1,52 @@
+USE [BookKeeping]
+GO
+/****** Object:  Trigger [dbo].[T_merchandise_insert_update]    Script Date: 7/27/2017 1:47:00 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+--Logs insert and update operations to the aliquot table.
+
+CREATE TRIGGER [dbo].[T_merchandise_insert_update] ON [dbo].[merchandise]
+AFTER INSERT, UPDATE
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @action CHAR(1)
+
+IF EXISTS(SELECT * FROM deleted) SET @action = 'U' ELSE SET @action = 'I'
+
+INSERT INTO merchandise_history
+	(merchandise_id,
+	 identifier,
+	 supplier_id,
+	 enabled, 
+	 comment,
+	 amount,
+	 appr_prize,
+	 storage,
+	 category,
+	 invoice_category_id,
+	 currency_id,
+	 changed_action)
+SELECT
+	 merchandise_id,
+	 identifier,
+	 supplier_id,
+	 enabled, 
+	 comment,
+	 amount,
+	 appr_prize,
+	 storage,
+	 category,
+	 invoice_category_id,
+	 currency_id,
+     @action
+FROM inserted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_post_delete.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_post_delete.sql
@@ -1,0 +1,77 @@
+USE [BookKeeping]
+GO
+CREATE TRIGGER [dbo].[T_post_delete] ON [dbo].[post]
+AFTER DELETE
+
+AS
+BEGIN 
+SET NOCOUNT ON
+
+INSERT INTO post_history
+	(post_id,
+	 article_number_id,
+	 authority_id_booker,
+	 book_date,
+	 merchandise_id,
+	 supplier_id,
+	 appr_prize,
+	 order_date,
+	 authority_id_orderer,
+	 predicted_arrival,
+	 invoice_inst,
+	 invoice_clin,
+	 arrival_date,
+	 arrival_sign,
+	 amount,
+	 invoice_status,
+	 authority_id_invoicer,
+	 invoice_date,
+	 invoice_absent,
+	 currency_id,
+	 changed_action,
+	 invoice_number,
+	 final_prize,
+	 authority_id_confirmed_order,
+	 confirmed_order_date,
+	 delivery_deviation,
+	 purchase_order_no,
+	 sales_order_no,
+	 place_of_purchase_id,
+	 customer_number_id)
+SELECT
+post_id,
+	 article_number_id,
+	 authority_id_booker,
+	 book_date,
+	 merchandise_id,
+	 supplier_id,
+	 appr_prize,
+	 order_date,
+	 authority_id_orderer,
+	 predicted_arrival,
+	 invoice_inst,
+	 invoice_clin,
+	 arrival_date,
+	 arrival_sign,
+	 amount,
+	 invoice_status,
+	 authority_id_invoicer,
+	 invoice_date,
+	 invoice_absent,
+	 currency_id,
+     'D',
+	 invoice_number,
+	 final_prize,
+	 authority_id_confirmed_order,
+	 confirmed_order_date,
+	 delivery_deviation,
+	 purchase_order_no,
+	 sales_order_no,
+	 place_of_purchase_id,
+	 customer_number_id
+FROM deleted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_post_insert_update.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_post_insert_update.sql
@@ -1,0 +1,88 @@
+USE [BookKeeping]
+GO
+/****** Object:  Trigger [dbo].[T_post_insert_update]    Script Date: 7/27/2017 1:47:00 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+--Logs insert and update operations to the aliquot table.
+
+CREATE TRIGGER [dbo].[T_post_insert_update] ON [dbo].[post]
+AFTER INSERT, UPDATE
+
+AS
+BEGIN
+SET NOCOUNT ON
+
+DECLARE @action CHAR(1)
+
+IF EXISTS(SELECT * FROM deleted) SET @action = 'U' ELSE SET @action = 'I'
+
+INSERT INTO post_history
+	(post_id,
+	 article_number_id,
+	 authority_id_booker,
+	 book_date,
+	 merchandise_id,
+	 supplier_id,
+	 appr_prize,
+	 order_date,
+	 authority_id_orderer,
+	 predicted_arrival,
+	 invoice_inst,
+	 invoice_clin,
+	 arrival_date,
+	 arrival_sign,
+	 amount,
+	 invoice_status,
+	 authority_id_invoicer,
+	 invoice_date,
+	 invoice_absent,
+	 currency_id,
+	 changed_action,
+	 invoice_number,
+	 final_prize,
+	 authority_id_confirmed_order,
+	 confirmed_order_date,
+	 delivery_deviation,
+	 purchase_order_no,
+	 sales_order_no,
+	 place_of_purchase_id,
+	 customer_number_id)
+SELECT
+	 post_id,
+	 article_number_id,
+	 authority_id_booker,
+	 book_date,
+	 merchandise_id,
+	 supplier_id,
+	 appr_prize,
+	 order_date,
+	 authority_id_orderer,
+	 predicted_arrival,
+	 invoice_inst,
+	 invoice_clin,
+	 arrival_date,
+	 arrival_sign,
+	 amount,
+	 invoice_status,
+	 authority_id_invoicer,
+	 invoice_date,
+	 invoice_absent,
+	 currency_id,
+     @action,
+	 invoice_number,
+	 final_prize,
+	 authority_id_confirmed_order,
+	 confirmed_order_date,
+	 delivery_deviation,
+	 purchase_order_no,
+	 sales_order_no,
+	 place_of_purchase_id,
+	 customer_number_id
+FROM inserted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_supplier_delete.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_supplier_delete.sql
@@ -1,0 +1,37 @@
+USE [BookKeeping]
+GO
+CREATE TRIGGER [dbo].[T_supplier_delete] ON [dbo].[supplier]
+AFTER DELETE
+
+AS
+BEGIN 
+SET NOCOUNT ON
+
+INSERT INTO supplier_history
+	(supplier_id,
+	 identifier,
+	 enabled, 
+	 comment,
+	 tel_nr,
+	 customer_nr_inst,
+	 customer_nr_clin,
+	 contract_terminate,
+	 short_name,
+	 changed_action)
+SELECT
+	 supplier_id,
+	 identifier,
+	 enabled, 
+	 comment,
+	 tel_nr,
+	 customer_nr_inst,
+	 customer_nr_clin,
+	 contract_terminate,
+	 short_name,
+     'D'
+FROM deleted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_triggers/T_supplier_insert_update.sql
+++ b/database_objects/BookKeeping_devel_triggers/T_supplier_insert_update.sql
@@ -1,0 +1,48 @@
+USE [BookKeeping]
+GO
+/****** Object:  Trigger [dbo].[T_supplier_insert_update]    Script Date: 7/27/2017 1:47:00 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+--Logs insert and update operations to the aliquot table.
+
+CREATE TRIGGER [dbo].[T_supplier_insert_update] ON [dbo].[supplier]
+AFTER INSERT, UPDATE
+
+AS
+BEGIN 
+SET NOCOUNT ON
+
+DECLARE @action CHAR(1)
+
+IF EXISTS(SELECT * FROM deleted) SET @action = 'U' ELSE SET @action = 'I'
+
+INSERT INTO supplier_history
+	(supplier_id,
+	 identifier,
+	 enabled, 
+	 comment,
+	 tel_nr,
+	 customer_nr_inst,
+	 customer_nr_clin,
+	 contract_terminate,
+	 short_name,
+	 changed_action)
+SELECT
+	 supplier_id,
+	 identifier,
+	 enabled, 
+	 comment,
+	 tel_nr,
+	 customer_nr_inst,
+	 customer_nr_clin,
+	 contract_terminate,
+	 short_name,
+     @action
+FROM inserted
+	
+SET NOCOUNT OFF
+END
+
+GO

--- a/database_objects/BookKeeping_devel_views/BookKeeping_devel_views.ssmssqlproj
+++ b/database_objects/BookKeeping_devel_views/BookKeeping_devel_views.ssmssqlproj
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<SqlWorkbenchSqlProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BookKeeping_devel_views">
+  <Items>
+    <LogicalFolder Name="Connections" Type="2" Sorted="true">
+      <Items />
+    </LogicalFolder>
+    <LogicalFolder Name="Queries" Type="0" Sorted="true">
+      <Items>
+        <FileNode Name="dbo.article_number_view.View.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.article_number_view.View.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.authority_view.View.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.authority_view.View.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.merchandise_view.View.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.merchandise_view.View.sql</FullPath>
+        </FileNode>
+        <FileNode Name="dbo.post_view.View.sql">
+          <AssociatedConnectionMoniker />
+          <AssociatedConnSrvName />
+          <AssociatedConnUserName />
+          <FullPath>dbo.post_view.View.sql</FullPath>
+        </FileNode>
+      </Items>
+    </LogicalFolder>
+    <LogicalFolder Name="Miscellaneous" Type="3" Sorted="true">
+      <Items />
+    </LogicalFolder>
+  </Items>
+</SqlWorkbenchSqlProject>

--- a/database_objects/BookKeeping_devel_views/dbo.article_number_view.sql
+++ b/database_objects/BookKeeping_devel_views/dbo.article_number_view.sql
@@ -1,0 +1,27 @@
+USE [BookKeeping]
+GO
+/****** Object:  View [dbo].[article_number_view]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE VIEW [dbo].[article_number_view] AS
+SELECT 
+	article_number_id as id,
+	identifier,
+	merchandise_id,
+	active
+FROM article_number
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_views/dbo.authority_view.sql
+++ b/database_objects/BookKeeping_devel_views/dbo.authority_view.sql
@@ -1,0 +1,30 @@
+USE [BookKeeping]
+GO
+/****** Object:  View [dbo].[authority_view]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+CREATE VIEW [dbo].[authority_view] AS
+SELECT 
+	a.authority_id AS id,
+	a.identifier,
+	a.name,
+	a.account_status,
+	a.user_type,
+	pop.code as place_of_purchase,
+	a.chiasma_barcode,
+	a.comment
+FROM authority a
+INNER JOIN place_of_purchase pop on a.place_of_purchase_id = pop.place_of_purchase_id
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_views/dbo.merchandise_view.sql
+++ b/database_objects/BookKeeping_devel_views/dbo.merchandise_view.sql
@@ -1,0 +1,41 @@
+USE [BookKeeping]
+GO
+/****** Object:  View [dbo].[merchandise_view]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+
+
+
+CREATE VIEW [dbo].[merchandise_view] AS
+SELECT 
+	m.merchandise_id AS id,
+	m.identifier,
+	m.supplier_id,
+	m.enabled,
+	m.comment,
+	m.amount,
+	m.appr_prize,
+	m.storage,
+	m.category,
+	m.invoice_category_id,
+	m.currency_id,
+	an.article_number_id,
+	an.identifier as article_number_identifier,
+	an.merchandise_id as article_number_merchandise_id,
+	an.active as article_number_active,
+	s.identifier as supplier_identifier
+FROM merchandise m 
+LEFT OUTER JOIN article_number an ON (an.merchandise_id = m.merchandise_id AND an.active = 1)
+LEFT OUTER JOIN supplier s ON (m.supplier_id = s.supplier_id)
+
+
+
+
+
+
+GO

--- a/database_objects/BookKeeping_devel_views/dbo.post_view.sql
+++ b/database_objects/BookKeeping_devel_views/dbo.post_view.sql
@@ -1,0 +1,64 @@
+USE [BookKeeping]
+GO
+/****** Object:  View [dbo].[post_view]    Script Date: 7/27/2017 1:42:18 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+CREATE VIEW [dbo].[post_view] AS
+SELECT 
+	p.post_id AS id,
+	p.comment,
+	p.authority_id_booker,
+	p.book_date,
+	p.merchandise_id,
+	p.supplier_id,
+	p.appr_prize,
+	p.order_date,
+	p.authority_id_orderer,
+	p.predicted_arrival,
+	p.invoice_inst,
+	p.invoice_clin,
+	p.arrival_date,
+	p.arrival_sign,
+	p.amount,
+	p.invoice_status,
+	p.authority_id_invoicer,
+	p.invoice_date,
+	p.invoice_absent,
+	p.currency_id,
+	p.article_number_id,
+	p.invoice_number,
+	p.final_prize,
+	p.authority_id_confirmed_order,
+	p.confirmed_order_date,
+	p.delivery_deviation,
+	p.purchase_order_no,
+	p.sales_order_no,
+	p.customer_number_id,
+	pop.code as place_of_purchase,
+	an.identifier as article_number_identifier,
+	an.active as article_number_active,
+	an.merchandise_id as article_number_merchandise_id,
+	m.identifier as merchandise_identifier,
+	m.amount as merchandise_amount,
+	m.enabled as merchandise_enabled,
+	m.comment as merchandise_comment,
+	s.identifier as supplier_identifier,
+	cn.description as customer_number_description,
+	cn.identifier as customer_number_identifier,
+	ic.number as invoice_category_number
+FROM post p
+INNER JOIN place_of_purchase pop on p.place_of_purchase_id = pop.place_of_purchase_id
+LEFT OUTER JOIN article_number an ON (an.article_number_id = p.article_number_id)
+LEFT OUTER JOIN merchandise m on m.merchandise_id = p.merchandise_id
+LEFT OUTER JOIN supplier s on s.supplier_id = p.supplier_id
+LEFT OUTER JOIN customer_number cn on cn.customer_number_id = p.customer_number_id
+LEFT OUTER JOIN invoice_category ic on m.invoice_category_id = ic.invoice_category_id
+
+
+
+GO

--- a/database_objects/database_objects.ssmssln
+++ b/database_objects/database_objects.ssmssln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# SQL Server Management Studio Solution File, Format Version 13.00
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "BookKeeping_devel_functions", "BookKeeping_devel_functions\BookKeeping_devel_functions.ssmssqlproj", "{4CAD9F40-EE03-45C7-A6AA-05FFBFCA8AFB}"
+EndProject
+Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "BookKeeping_devel_procedures", "BookKeeping_devel_procedures\BookKeeping_devel_procedures.ssmssqlproj", "{3D9C3D4D-F25A-4BCD-AE68-5FE78B02AD67}"
+EndProject
+Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "BookKeeping_devel_views", "BookKeeping_devel_views\BookKeeping_devel_views.ssmssqlproj", "{F7155F49-B8ED-4320-9AE1-E0BB5EDCB1D9}"
+EndProject
+Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "BookKeeping_devel_roles", "BookKeeping_devel_roles\BookKeeping_devel_roles.ssmssqlproj", "{79684999-719E-4E57-BA3D-D67C85CC3D7F}"
+EndProject
+Project("{4F2E2C19-372F-40D8-9FA7-9D2138C6997A}") = "BookKeeping_devel_triggers", "BookKeeping_devel_triggers\BookKeeping_devel_triggers.ssmssqlproj", "{3EA3AB0A-52FE-49FC-BCD2-07711243F1DB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Default|Default = Default|Default
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2E6EF130-2491-4F4D-ACE6-F5C38DBE38E6}.Default|Default.ActiveCfg = Default
+		{4CAD9F40-EE03-45C7-A6AA-05FFBFCA8AFB}.Default|Default.ActiveCfg = Default
+		{3D9C3D4D-F25A-4BCD-AE68-5FE78B02AD67}.Default|Default.ActiveCfg = Default
+		{F7155F49-B8ED-4320-9AE1-E0BB5EDCB1D9}.Default|Default.ActiveCfg = Default
+		{79684999-719E-4E57-BA3D-D67C85CC3D7F}.Default|Default.ActiveCfg = Default
+		{3EA3AB0A-52FE-49FC-BCD2-07711243F1DB}.Default|Default.ActiveCfg = Default
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Including user defined sql scripts for functions, procedures, views, triggers and
user roles.

These scripts are generated by the generate script right click option in ms sql management studio, applied to the BookKepping_practice db. Trigger-scripts were not included in this option, they are instead hand picked by rightclicking individual tables and chosing generate script option, therafter the trigger scripts are manually extracted. 

There has been some disorder in the source control for the Order database scripts. In winter 2014 considerable changes were done in the devel-db, but never finished, so that the db-scheme for operational db and devel db differed. With this pull request the sql scripts in source control should match the operational db.